### PR TITLE
CLXv2

### DIFF
--- a/Backends/CLXv2/event-manager.lisp
+++ b/Backends/CLXv2/event-manager.lisp
@@ -1,0 +1,163 @@
+(in-package :clim-clxv2)
+
+;;;
+;;; pointer events
+;;;
+(defmethod climi::distribute-event :before ((port clxv2-port) (event pointer-button-press-event))
+  (setf (port-pointer-pressed-sheet port) (port-pointer-sheet port)))
+
+(defmethod climi::distribute-event :after ((port clxv2-port) (event pointer-button-release-event))
+  (setf (port-pointer-pressed-sheet port) nil))
+
+(defmethod climi::distribute-event :around ((port clxv2-port) (event pointer-event))
+  (let ((grab-sheet (clim-clx::pointer-grab-sheet port))
+	(pointer-pressed-sheet (port-pointer-pressed-sheet port))
+	(pointer-sheet (get-pointer-event-sheet (event-sheet event) event))
+	(old-pointer-sheet (or (port-pointer-sheet port) (event-sheet event)))
+	(top-level-sheet (get-top-level-sheet (event-sheet event))))
+    (cond
+      (grab-sheet
+       (if (sheet-ancestor-p pointer-sheet grab-sheet)
+	   (setf pointer-sheet grab-sheet)
+	   (setf pointer-sheet (sheet-parent grab-sheet))))
+      ((typep top-level-sheet 'unmanaged-top-level-sheet-pane)
+       nil)
+      (pointer-pressed-sheet
+       (if (sheet-ancestor-p pointer-sheet pointer-pressed-sheet)
+	   (setf pointer-sheet pointer-pressed-sheet)
+	   (setf pointer-sheet (sheet-parent pointer-pressed-sheet))))
+      (t
+       nil))
+    (let ((common-sheet (sheet-common-ancestor old-pointer-sheet pointer-sheet)))
+      (distribute-exit-events old-pointer-sheet common-sheet event)
+      (distribute-enter-events pointer-sheet common-sheet event)
+      (setf (port-pointer-sheet port) pointer-sheet))
+    (unless (or (typep event 'pointer-enter-event)
+		(typep event 'pointer-exit-event))
+      (cond
+	((typep top-level-sheet 'unmanaged-top-level-sheet-pane)
+	 (call-next-method))
+	((or grab-sheet pointer-pressed-sheet)
+	 (cond
+	   ((eq pointer-sheet (or grab-sheet pointer-pressed-sheet))
+	    (call-next-method))
+	   ((typep event 'pointer-button-release-event)
+	    ;; send event to ...
+	    (setf (port-pointer-sheet port) (or grab-sheet pointer-pressed-sheet))
+	    (call-next-method))
+	   (t
+	    nil)))
+	(t
+	 (call-next-method))))))
+
+
+(defmethod climi::distribute-event ((port clxv2-port) (event pointer-event))
+  (let ((sheet (port-pointer-sheet port)))
+    (when sheet
+      (cond ((eq sheet (event-sheet event))
+	     (dispatch-event sheet event))
+	    (t 
+	     (dispatch-event sheet
+			     (make-instance (type-of event)
+					    :pointer (slot-value event 'climi::pointer)
+					    :button (slot-value event 'climi::button)
+					    :x (slot-value event 'climi::x)
+					    :y (slot-value event 'climi::y)
+					    :graft-x (slot-value event 'climi::graft-x)
+					    :graft-y (slot-value event 'climi::graft-y)
+					    :sheet sheet
+					    :modifier-state (slot-value event 'climi::modifier-state)
+					    :timestamp (slot-value event 'climi::timestamp))))))))
+;;;
+;;; repaint 
+;;;
+
+
+;;;
+;;; all events
+;;;
+
+(defmethod climi::distribute-event ((port clxv2-port) event)
+  (cond
+   ((typep event 'keyboard-event)
+    (dispatch-event (event-sheet event) event))
+   ((typep event 'window-event)
+    (dispatch-event (event-sheet event) event))
+   ((typep event 'window-manager-delete-event)
+    ;; not sure where this type of event should get sent - mikemac
+    ;; This seems fine; will be handled by the top-level-sheet-pane - moore
+    (dispatch-event (event-sheet event) event))
+   ((typep event 'timer-event)
+    (error "Where do we send timer-events?"))
+   (t
+    (error "Unknown event ~S received in DISTRIBUTE-EVENT" event))))
+
+
+(defun distribute-enter-events (sheet-b sheet-t event)
+  (dolist (s
+	    (do ((s sheet-b (sheet-parent s))
+		 (lis nil))
+		((or (null s) (climi::graftp s) (eq s sheet-t)) lis)
+	      (push s lis)))
+    (format *debug-io* "enter ~A ~%" s)
+    (dispatch-event s 
+		    (make-instance 'pointer-enter-event
+				   :pointer (slot-value event 'climi::pointer)
+				   :button nil
+				   :x (slot-value event 'climi::x) ;; wrong?
+				   :y (slot-value event 'climi::y) ;; wrong?
+				   :graft-x (slot-value event 'climi::graft-x)
+				   :graft-y (slot-value event 'climi::graft-y)
+				   :sheet s
+				   :modifier-state (slot-value event 'climi::modifier-state)
+				   :timestamp (slot-value event 'climi::timestamp)))))
+
+(defun distribute-exit-events (sheet-b sheet-t event)
+  (when (and sheet-t sheet-b)
+    (do ((s sheet-b (sheet-parent s)))
+	((or (null s) (climi::graftp s) (eq s sheet-t)))
+      (format *debug-io* "exit ~A ~A ~A~%" s (slot-value event 'climi::x)(slot-value event 'climi::y) )
+      (dispatch-event s
+		      (make-instance 'pointer-exit-event
+				     :pointer (slot-value event 'climi::pointer)
+				     :button nil
+				     :x (slot-value event 'climi::x) ;; wrong?
+				     :y (slot-value event 'climi::y) ;; wrong?
+				     :graft-x (slot-value event 'climi::graft-x)
+				     :graft-y (slot-value event 'climi::graft-y)
+				     :sheet s
+				     :modifier-state (slot-value event 'climi::modifier-state)
+				     :timestamp (slot-value event 'climi::timestamp))))))
+
+
+(defun sheet-common-ancestor (sheet-a sheet-b)
+  (cond
+    ((null sheet-a)
+     nil)
+    ((climi::graftp sheet-a)
+     sheet-a)
+    ((sheet-ancestor-p sheet-b sheet-a)
+     sheet-a)
+    (t
+     (sheet-common-ancestor (sheet-parent sheet-a) sheet-b))))
+
+(defun get-top-level-sheet (sheet)
+  (cond
+    ((null sheet)
+     nil)
+    ((typep sheet 'top-level-sheet-pane)
+     sheet)
+    (t
+     (get-top-level-sheet (sheet-parent sheet)))))
+  
+(defun get-pointer-event-sheet (sheet event)
+  (labels ((get-pointer-event-sheet-2 (sheet x y)
+	     (let ((child (child-containing-position sheet x y)))
+	       ;; only not mirrored child?
+	       (if child
+		   (multiple-value-bind (cx cy)
+		       (untransform-position (sheet-transformation child) x y)
+		     (get-pointer-event-sheet-2 child  cx cy))
+		   sheet))))
+    (climi::get-pointer-position (sheet event)
+      (get-pointer-event-sheet-2 sheet climi::x climi::y))))

--- a/Backends/CLXv2/frame-manager.lisp
+++ b/Backends/CLXv2/frame-manager.lisp
@@ -1,0 +1,60 @@
+(in-package :clim-clxv2)
+
+
+
+(defclass clxv2-frame-manager (clim-clx::clx-frame-manager)
+  ())
+
+
+;; the panes to be mirrored
+(defun get-mirroring-fn (port)
+  (cond ((or (null (clxv2-port-mirroring port))
+	     (eq (clxv2-port-mirroring port) :all-basic-panes))
+	 #'(lambda (pane-class)
+	     (subtypep pane-class 'basic-pane)))
+	((eq (clxv2-port-mirroring port) :none)
+	 #'(lambda (pane-class)
+	     (subtypep pane-class 'top-level-sheet-pane)))
+	((eq (clxv2-port-mirroring port) :gadgets)
+	 #'(lambda (pane-class)
+	     (or (subtypep pane-class 'top-level-sheet-pane)
+		 (subtypep pane-class 'gadget))))
+	(t
+	 #'(lambda (pane-class)
+	     (declare (ignore pane-class))
+	     nil))))
+
+;;; if the pane is a subclass of basic-pane and it is not mirrored we create a new class.
+(defun maybe-mirroring (port concrete-pane-class)
+  (when (and (not (subtypep concrete-pane-class 'mirrored-sheet-mixin))
+	     (funcall (get-mirroring-fn port) concrete-pane-class))
+    (let* ((concrete-pane-class-symbol (if (typep concrete-pane-class 'class)
+                                          (class-name concrete-pane-class)
+                                          concrete-pane-class))
+	   (concrete-mirrored-pane-class (concatenate 'string
+						      "CLXv2-"
+						      (symbol-name concrete-pane-class-symbol)
+						      "-DUMMY"))
+	   (concrete-mirrored-pane-class-symbol (find-symbol concrete-mirrored-pane-class
+							     :clim-clxv2)))
+      (format *debug-io* "use dummy mirrored class ~A ~A~%" (clxv2-port-mirroring port) concrete-mirrored-pane-class)
+      (unless concrete-mirrored-pane-class-symbol
+	(setf concrete-mirrored-pane-class-symbol
+	      (intern concrete-mirrored-pane-class :clim-clxv2))
+	(eval
+	 `(defclass ,concrete-mirrored-pane-class-symbol
+	      (clxv2-mirrored-sheet-mixin
+	       ,concrete-pane-class-symbol)
+	    ()
+	    (:metaclass ,(type-of (find-class concrete-pane-class-symbol)))))
+	(format *debug-io* "create class ~A~%" concrete-mirrored-pane-class-symbol))
+      (setf concrete-pane-class (find-class concrete-mirrored-pane-class-symbol))))
+  concrete-pane-class)
+
+(defmethod make-pane-1 ((fm clxv2-frame-manager) (frame application-frame) type &rest args)
+  (apply #'make-instance
+	 (maybe-mirroring (port fm) (clim-clx::find-concrete-pane-class type))
+	 :frame frame
+	 :manager fm
+	 :port (port frame)
+	 args))

--- a/Backends/CLXv2/mcclim-clxv2.asd
+++ b/Backends/CLXv2/mcclim-clxv2.asd
@@ -1,0 +1,14 @@
+
+(defsystem #:mcclim-clxv2
+  :depends-on (#:mcclim-clx)
+
+  :components
+  ((:file "package")
+   (:file "port" :depends-on ("package"))
+   (:file "frame-manager" :depends-on ("port" "package"))
+   (:file "event-manager" :depends-on ("port" "package"))))
+
+(defsystem #:mcclim-clxv2/pretty
+    :depends-on (#:mcclim-clxv2
+		 #:mcclim-clx/pretty))
+

--- a/Backends/CLXv2/package.lisp
+++ b/Backends/CLXv2/package.lisp
@@ -1,0 +1,57 @@
+;;; -*- Mode: Lisp; Package: COMMON-LISP-USER -*-
+
+(in-package :common-lisp-user)
+
+(defpackage :clim-clxv2
+    (:use :clim :clim-lisp :clim-backend :clim-clx)
+  (:import-from :climi
+                #:+alt-key+
+                ;;
+                #:port-text-style-mappings
+                #:port-lookup-mirror
+                #:port-register-mirror
+                #:port-event-process
+                #:port-grafts
+                #:update-mirror-geometry
+                #:%sheet-mirror-region
+                #:%sheet-mirror-transformation
+                ;;
+                #:clamp
+                #:get-environment-variable
+                #:pixmap-sheet
+                #:port-lookup-sheet
+                #:port-unregister-mirror
+		#:port-pointer-sheet
+                #:map-repeated-sequence
+                #:pixmap-mirror
+		#:do-sequence
+                #:with-double-buffering 
+                #:with-transformed-position
+                #:with-transformed-positions
+                #:with-medium-options
+                ;;
+                #:border-pane
+                #:pixmap
+                #:top-level-sheet-pane
+                #:unmanaged-top-level-sheet-pane
+                #:menu-frame
+                ;;
+                #:frame-managers        ;used as slot
+                #:top-level-sheet       ;used as slot
+                #:medium-device-region
+                #:draw-image
+                #:height                ;this seems bogus
+                #:width                 ;dito
+                #:coordinate=
+                #:get-transformation
+                ;;
+                #:invoke-with-special-choices
+                #:medium-miter-limit
+                ;; classes:
+                #:mirrored-pixmap
+                #:window-destroy-event
+                #:pointer-ungrab-event
+		#:pointer-motion-hint-event
+                #:device-font-text-style
+                ;;
+                ) )

--- a/Backends/CLXv2/port.lisp
+++ b/Backends/CLXv2/port.lisp
@@ -1,0 +1,72 @@
+(in-package :clim-clxv2)
+
+(defclass clxv2-port (clim-clx::clx-port)
+  ((mirroring :accessor clxv2-port-mirroring)
+   (port-pointer-pressed-sheet :initform nil :accessor port-pointer-pressed-sheet)))
+
+(defun parse-clxv2-server-path (path)
+  (let ((server-path (clim-clx::parse-clx-server-path path)))
+    (pop path)
+    (cons :clxv2 (append (list :mirroring  (getf path :mirroring :none)) (cdr server-path)))))
+
+(setf (get :clxv2 :port-type) 'clxv2-port)
+(setf (get :clxv2 :server-path-parser) 'parse-clxv2-server-path)
+
+(defmethod initialize-instance :after ((port clxv2-port) &rest args)
+  (declare (ignore args))
+  (push (make-instance 'clxv2-frame-manager :port port)
+	(slot-value port 'frame-managers))
+  (setf (slot-value port 'mirroring)
+	(getf (cdr (port-server-path port)) :mirroring)))
+
+
+(defparameter *event-mask* '(:exposure 
+			     :key-press :key-release
+			     :button-press :button-release
+			     :owner-grab-button
+			     :enter-window :leave-window
+			     :structure-notify
+			     :pointer-motion :button-motion))
+
+(defmethod clim-clx::%realize-mirror ((port clxv2-port) (sheet basic-sheet))
+  (clim-clx::realize-mirror-aux port sheet
+		      :event-mask *event-mask*
+                      :border-width 0
+                      :map (sheet-enabled-p sheet)))
+
+(defmethod clim-clx::%realize-mirror ((port clxv2-port) (sheet top-level-sheet-pane))
+  (let ((q (compose-space sheet)))
+    (let ((frame (pane-frame sheet))
+          (window (clim-clx::realize-mirror-aux port sheet
+				      :event-mask *event-mask*
+                                      :map nil
+                                      :width (clim-clx::round-coordinate (space-requirement-width q))
+                                      :height (clim-clx::round-coordinate (space-requirement-height q)))))           
+      (setf (xlib:wm-hints window) (xlib:make-wm-hints :input :on))
+      (setf (xlib:wm-name window) (frame-pretty-name frame))
+      (setf (xlib:wm-icon-name window) (frame-pretty-name frame))
+      (xlib:set-wm-class
+       window
+       (string-downcase (frame-name frame))
+       (string-capitalize (string-downcase (frame-name frame))))
+      (setf (xlib:wm-protocols window) `(:wm_delete_window))
+      (xlib:change-property window
+                            :WM_CLIENT_LEADER (list (xlib:window-id window))
+                            :WINDOW 32))))
+
+(defmethod clim-clx::%realize-mirror ((port clxv2-port) (sheet unmanaged-top-level-sheet-pane))
+  (clim-clx::realize-mirror-aux port sheet
+		      :event-mask *event-mask*
+		      :override-redirect :on
+		      :map nil))
+
+
+
+;;;
+;;;
+;;;
+
+(defclass clxv2-mirrored-sheet-mixin (mirrored-sheet-mixin)
+  ())
+
+

--- a/Core/clim-basic/sheets.lisp
+++ b/Core/clim-basic/sheets.lisp
@@ -901,11 +901,12 @@ very hard)."
           ;; needs to be computed initially
           (t
            (let* ((parent (sheet-parent sheet))
+		  (mirrored-ancestor (sheet-mirrored-ancestor parent))
                   (sheet-region-in-native-parent
                    ;; this now is the wanted sheet mirror region
-                   (transform-region (sheet-native-transformation parent)
-                                     (transform-region (sheet-transformation sheet)
-                                                       (sheet-region sheet)))))
+		   (transform-region (sheet-native-transformation parent)
+				      (transform-region (sheet-transformation sheet)
+							(sheet-region sheet)))))
              (when (region-equal sheet-region-in-native-parent +nowhere+)
                ;; hmm
                (setf (%sheet-mirror-transformation sheet)
@@ -926,8 +927,8 @@ very hard)."
              (with-bounding-rectangle* (mx1 my1 mx2 my2)
 				       sheet-region-in-native-parent
                (let (;; pw, ph is the width/height of the parent
-                     (pw  (bounding-rectangle-width (sheet-mirror-region parent)))
-                     (ph  (bounding-rectangle-height (sheet-mirror-region parent))))
+                     (pw  (bounding-rectangle-width (sheet-mirror-region mirrored-ancestor)))
+                     (ph  (bounding-rectangle-height (sheet-mirror-region mirrored-ancestor))))
                  (labels ((choose (MT)
                             ;; -> fits-p mirror-region
                             (multiple-value-bind (x1 y1) (transform-position MT 0 0)
@@ -948,7 +949,7 @@ very hard)."
                    (when old-native-transformation
                      (let ((MT (compose-transformations
                                 (compose-transformations
-                                 (sheet-native-transformation (sheet-parent sheet))
+                                 (sheet-native-transformation parent)
                                  (sheet-transformation sheet))
                                 (invert-transformation old-native-transformation))))
                        (multiple-value-bind (fits-p MR) (choose MT)
@@ -978,7 +979,7 @@ very hard)."
                                   (compose-transformations
                                    (invert-transformation MT)
                                    (compose-transformations
-                                    (sheet-native-transformation (sheet-parent sheet))
+                                    (sheet-native-transformation parent)
                                     (sheet-transformation sheet)))))
                              ;; finally reflect the change to the host window system
                              (setf (%sheet-mirror-region sheet) MR)


### PR DESCRIPTION
Hi Daniel,
here there is my  CLXv2 Backend (and a small fix to update-geometry). You can load it with: 
```
(ql:quickload :mcclim-clxv2/pretty).
```

You can use the mirroring option to decide which panes you want to be mirrored. At the moment there are three option: :all-basic-panes, :gadgets, and :none. Es:
```
(let ((clim:*default-server-path*  '(:clxv2 :mirroring :all-basic-panes)))
    (CLIM-DEMO:DEMODEMO))

(let ((clim:*default-server-path*  '(:clxv2 :host ""
				       :protocol :unix
				       :display-id 0
				       :mirroring :gadgets)))
    (CLIM-DEMO:DEMODEMO))

(let ((clim:*default-server-path*  '(:clxv2 :host ""
				       :protocol :unix
				       :display-id 0
				       :mirroring :none)))
    (CLIM-DEMO:DEMODEMO))
```