### PR TITLE
Danieldev

### DIFF
--- a/Backends/CLX/port.lisp
+++ b/Backends/CLX/port.lisp
@@ -379,7 +379,7 @@
   (when (null (port-lookup-mirror port sheet))
     ;;(update-mirror-geometry sheet (%%sheet-native-transformation sheet))
     (let* ((desired-color (typecase sheet
-                            (sheet-with-medium-mixin
+                            (permanent-medium-sheet-output-mixin ;; sheet-with-medium-mixin
                               (medium-background sheet))
                             (basic-pane ; CHECKME [is this sensible?] seems to be
                               (let ((background (pane-background sheet)))
@@ -1230,8 +1230,10 @@
     (setf (pointer-grab-sheet port) nil)))
 
 (defmethod set-sheet-pointer-cursor ((port clx-port) (sheet mirrored-sheet-mixin) cursor)
-  (let ((cursor (gethash (or cursor :default) (clx-port-cursor-table port))))
-    (when cursor
+  (let ((cursor (gethash (or cursor :default) (clx-port-cursor-table port)))
+	(mirror (sheet-direct-mirror sheet)))
+    (when (and cursor
+	       (typep mirror 'xlib:window))
       (setf (xlib:window-cursor (sheet-direct-mirror sheet)) cursor))))
         
 

--- a/Backends/CLXv2/frame-manager.lisp
+++ b/Backends/CLXv2/frame-manager.lisp
@@ -36,15 +36,21 @@
 						      (symbol-name concrete-pane-class-symbol)
 						      "-DUMMY"))
 	   (concrete-mirrored-pane-class-symbol (find-symbol concrete-mirrored-pane-class
-							     :clim-clxv2)))
+							     :clim-clxv2))
+	   (superclasses (if (subtypep concrete-pane-class 'sheet-with-medium-mixin)
+			     (list 'clxv2-mirrored-sheet-mixin
+				   concrete-pane-class-symbol)
+			     (list 'clxv2-mirrored-sheet-mixin
+				   ;;'temporary-medium-sheet-output-mixin
+				   'permanent-medium-sheet-output-mixin
+				   concrete-pane-class-symbol))))
       (format *debug-io* "use dummy mirrored class ~A ~A~%" (clxv2-port-mirroring port) concrete-mirrored-pane-class)
       (unless concrete-mirrored-pane-class-symbol
 	(setf concrete-mirrored-pane-class-symbol
 	      (intern concrete-mirrored-pane-class :clim-clxv2))
 	(eval
 	 `(defclass ,concrete-mirrored-pane-class-symbol
-	      (clxv2-mirrored-sheet-mixin
-	       ,concrete-pane-class-symbol)
+	      ,superclasses
 	    ()
 	    (:metaclass ,(type-of (find-class concrete-pane-class-symbol)))))
 	(format *debug-io* "create class ~A~%" concrete-mirrored-pane-class-symbol))

--- a/Backends/CLXv3/frame-manager.lisp
+++ b/Backends/CLXv3/frame-manager.lisp
@@ -23,14 +23,20 @@
 						      (symbol-name concrete-pane-class-symbol)
 						      "-DUMMY"))
 	   (concrete-mirrored-pane-class-symbol (find-symbol concrete-mirrored-pane-class
-							     :clim-clxv3)))
+							     :clim-clxv3))
+	   (superclasses (if (subtypep concrete-pane-class 'sheet-with-medium-mixin)
+			     (list 'clxv3-mirrored-sheet-mixin
+				   concrete-pane-class-symbol)
+			     (list 'clxv3-mirrored-sheet-mixin
+				   ;;'temporary-medium-sheet-output-mixin
+				   'permanent-medium-sheet-output-mixin
+				   concrete-pane-class-symbol))))
       (unless concrete-mirrored-pane-class-symbol
 	(setf concrete-mirrored-pane-class-symbol
 	      (intern concrete-mirrored-pane-class :clim-clxv3))
 	(eval
 	 `(defclass ,concrete-mirrored-pane-class-symbol
-	      (clxv3-mirrored-sheet-mixin
-	       ,concrete-pane-class-symbol)
+	      ,superclasses
 	    ()
 	    (:metaclass ,(type-of (find-class concrete-pane-class-symbol)))))
 	(format *debug-io* "create class ~A~%" concrete-mirrored-pane-class-symbol))

--- a/Backends/Standard/events.lisp
+++ b/Backends/Standard/events.lisp
@@ -66,11 +66,12 @@
       (distribute-enter-events pointer-sheet common-sheet event)
       (setf (port-pointer-sheet port) pointer-sheet))
     ;; set the pointer cursor
-    (let ((pointer-cursor
-	   (sheet-pointer-cursor (port-pointer-sheet port))))
-      (unless (eql (port-lookup-current-pointer-cursor port (event-sheet event))
-		       pointer-cursor)
-	(set-sheet-pointer-cursor port (event-sheet event) pointer-cursor)))
+    (when (port-pointer-sheet port)
+      (let ((pointer-cursor
+	     (sheet-pointer-cursor (port-pointer-sheet port))))
+	(unless (eql (port-lookup-current-pointer-cursor port (event-sheet event))
+		     pointer-cursor)
+	  (set-sheet-pointer-cursor port (event-sheet event) pointer-cursor))))
     (unless (or (typep event 'pointer-enter-event)
                 (typep event 'pointer-exit-event))
       (cond

--- a/Backends/Standard/events.lisp
+++ b/Backends/Standard/events.lisp
@@ -24,20 +24,19 @@
 	  (t
 	   (error "Unknown event ~S received in DISTRIBUTE-EVENT" event))))))
 
-
-
 (defclass standard-handled-event-port-mixin (standard-event-port-mixin)
   ((port-pointer-pressed-sheet :initform nil :accessor port-pointer-pressed-sheet)))
-
 
 
 ;;;
 ;;; pointer events
 ;;;
-(defmethod climi::distribute-event :before ((port standard-handled-event-port-mixin) (event pointer-button-press-event))
+(defmethod climi::distribute-event :before ((port standard-handled-event-port-mixin)
+					    (event pointer-button-press-event))
   (setf (port-pointer-pressed-sheet port) (port-pointer-sheet port)))
 
-(defmethod climi::distribute-event :after ((port standard-handled-event-port-mixin) (event pointer-button-release-event))
+(defmethod climi::distribute-event :after ((port standard-handled-event-port-mixin)
+					   (event pointer-button-release-event))
   (setf (port-pointer-pressed-sheet port) nil))
 
 (defmethod climi::distribute-event :around ((port standard-handled-event-port-mixin) (event pointer-event))
@@ -48,9 +47,12 @@
         (top-level-sheet (get-top-level-sheet (event-sheet event))))
     (cond
       (grab-sheet
-       (if (sheet-ancestor-p pointer-sheet grab-sheet)
-           (setf pointer-sheet grab-sheet)
-           (setf pointer-sheet (sheet-parent grab-sheet))))
+       (setf (port-pointer-sheet port) pointer-sheet)
+       (call-next-method)
+       ;;(if (sheet-ancestor-p pointer-sheet grab-sheet)
+       ;;    (setf pointer-sheet grab-sheet)
+       ;;    (setf pointer-sheet (sheet-parent grab-sheet))))
+       nil)
       ((typep (event-sheet event) 'unmanaged-top-level-sheet-pane)
        nil)
       ((typep top-level-sheet 'unmanaged-top-level-sheet-pane)
@@ -61,69 +63,75 @@
            (setf pointer-sheet (sheet-parent pointer-pressed-sheet))))
       (t
        nil))
-    (let ((common-sheet (sheet-common-ancestor old-pointer-sheet pointer-sheet)))
-      (distribute-exit-events old-pointer-sheet common-sheet event)
-      (distribute-enter-events pointer-sheet common-sheet event)
-      (setf (port-pointer-sheet port) pointer-sheet))
-    ;; set the pointer cursor
-    (when pointer-sheet
-      (let ((pointer-cursor
-	     (sheet-pointer-cursor pointer-sheet)))
-	(unless (eql (port-lookup-current-pointer-cursor port (event-sheet event))
-		     pointer-cursor)
-	  (set-sheet-pointer-cursor port (event-sheet event) pointer-cursor))))
-    (unless (or (typep event 'pointer-enter-event)
-                (typep event 'pointer-exit-event))
-      (cond
-        ((typep top-level-sheet 'unmanaged-top-level-sheet-pane)
-         (call-next-method))
-        ((or grab-sheet pointer-pressed-sheet)
-         (cond
-           ((eq pointer-sheet (or grab-sheet pointer-pressed-sheet))
-            (call-next-method))
-           ((or (typep event 'pointer-button-release-event)
-                (typep event 'pointer-motion-event))
-            ;; send event to ...
-            (setf (port-pointer-sheet port) (or grab-sheet pointer-pressed-sheet))
-            (call-next-method)
-            (setf (port-pointer-sheet port) pointer-sheet))
-           (t
-            nil)))
-        (t	 
-         (call-next-method))))))
+    (unless grab-sheet
+      ;; distribute exit and enter events
+      (let ((common-sheet (sheet-common-ancestor old-pointer-sheet pointer-sheet)))
+	(distribute-exit-events old-pointer-sheet common-sheet event)
+	(distribute-enter-events pointer-sheet common-sheet event)
+	(setf (port-pointer-sheet port) pointer-sheet))
+      ;; set the pointer cursor
+      (when pointer-sheet
+	(let ((pointer-cursor
+	       (sheet-pointer-cursor pointer-sheet)))
+	  (unless (eql (port-lookup-current-pointer-cursor port (event-sheet event))
+		       pointer-cursor)
+	    (set-sheet-pointer-cursor port (event-sheet event) pointer-cursor))))
+      (unless (or (typep event 'pointer-enter-event)
+		  (typep event 'pointer-exit-event))
+	(cond
+	  ((typep top-level-sheet 'unmanaged-top-level-sheet-pane)
+	   (call-next-method))
+	  ((or grab-sheet pointer-pressed-sheet)
+	   (cond
+	     ((eq pointer-sheet (or grab-sheet pointer-pressed-sheet))
+	      (call-next-method))
+	     ((or (typep event 'pointer-button-release-event)
+		  (typep event 'pointer-motion-event))
+	      ;; send event to ...
+	      (setf (port-pointer-sheet port) (or grab-sheet pointer-pressed-sheet))
+	      (call-next-method)
+	      (setf (port-pointer-sheet port) pointer-sheet))
+	     (t
+	      nil)))
+	  (t	 
+	   (call-next-method)))))))
 
 
 (defmethod climi::distribute-event ((port standard-handled-event-port-mixin) (event pointer-event))
-
-  (let ((sheet (port-pointer-sheet port)))
+  (let* ((sheet (port-pointer-sheet port))
+	 (grab-sheet (pointer-grab-sheet port))
+	 (destination (or (pointer-grab-sheet port) sheet)))
     (when sheet
       (cond ((eq sheet (event-sheet event))
-	     
-             (dispatch-event sheet event))
-            (t
-             (if (eq (sheet-mirrored-ancestor sheet) (sheet-mirrored-ancestor (event-sheet event)))
-                 (dispatch-event sheet
-                                 (make-instance (type-of event)
-                                                :pointer (slot-value event 'climi::pointer)
-                                                :button (slot-value event 'climi::button)
-                                                :x (slot-value event 'climi::x)
-                                                :y (slot-value event 'climi::y)
-                                                :graft-x (slot-value event 'climi::graft-x)
-                                                :graft-y (slot-value event 'climi::graft-y)
-                                                :sheet sheet
-                                                :modifier-state (slot-value event 'climi::modifier-state)
-                                                :timestamp (slot-value event 'climi::timestamp)))
-                 (dispatch-event sheet
-                                 (make-instance (type-of event)
-                                                :pointer (slot-value event 'climi::pointer)
-                                                :button (slot-value event 'climi::button)
-                                                :x (slot-value event 'climi::x)  ;; wrong value
-                                                :y (slot-value event 'climi::y)  ;; wrong value
-                                                :graft-x (slot-value event 'climi::graft-x)
-                                                :graft-y (slot-value event 'climi::graft-y)
-                                                :sheet sheet
-                                                :modifier-state (slot-value event 'climi::modifier-state)
-                                                :timestamp (slot-value event 'climi::timestamp)))))))))
+	     (dispatch-event sheet event))
+            ((eq (sheet-mirrored-ancestor sheet) (sheet-mirrored-ancestor (event-sheet event)))
+	     (dispatch-event destination
+			     (make-instance (type-of event)
+					    :pointer (slot-value event 'climi::pointer)
+					    :button (slot-value event 'climi::button)
+					    :x (slot-value event 'climi::x)
+					    :y (slot-value event 'climi::y)
+					    :graft-x (slot-value event 'climi::graft-x)
+					    :graft-y (slot-value event 'climi::graft-y)
+					    :sheet sheet
+					    :modifier-state (slot-value event 'climi::modifier-state)
+					    :timestamp (slot-value event 'climi::timestamp))))
+	    (t
+	     (multiple-value-bind (cx cy)
+		 (untransform-position (sheet-delta-transformation (sheet-mirrored-ancestor sheet) nil)
+				     (slot-value event 'climi::graft-x)
+				     (slot-value event 'climi::graft-y))
+	     (dispatch-event destination
+			     (make-instance (type-of event)
+					    :pointer (slot-value event 'climi::pointer)
+					    :button (slot-value event 'climi::button)
+					    :x cx
+					    :y cy
+					    :graft-x (slot-value event 'climi::graft-x)
+					    :graft-y (slot-value event 'climi::graft-y)
+					    :sheet sheet
+					    :modifier-state (slot-value event 'climi::modifier-state)
+					    :timestamp (slot-value event 'climi::timestamp)))))))))
 
 
 
@@ -136,20 +144,7 @@
 ;;; all events
 ;;;
 
-(defmethod climi::distribute-event ((port standard-handled-event-port-mixin) event)
-  (cond
-   ((typep event 'keyboard-event)
-    (dispatch-event (event-sheet event) event))
-   ((typep event 'window-event)
-    (dispatch-event (event-sheet event) event))
-   ((typep event 'window-manager-delete-event)
-    ;; not sure where this type of event should get sent - mikemac
-    ;; This seems fine; will be handled by the top-level-sheet-pane - moore
-    (dispatch-event (event-sheet event) event))
-   ((typep event 'timer-event)
-    (error "Where do we send timer-events?"))
-   (t
-    (error "Unknown event ~S received in DISTRIBUTE-EVENT" event))))
+
 
 
 (defun distribute-enter-events (sheet-b sheet-t event)

--- a/Backends/Standard/events.lisp
+++ b/Backends/Standard/events.lisp
@@ -66,9 +66,9 @@
       (distribute-enter-events pointer-sheet common-sheet event)
       (setf (port-pointer-sheet port) pointer-sheet))
     ;; set the pointer cursor
-    (when (port-pointer-sheet port)
+    (when pointer-sheet
       (let ((pointer-cursor
-	     (sheet-pointer-cursor (port-pointer-sheet port))))
+	     (sheet-pointer-cursor pointer-sheet)))
 	(unless (eql (port-lookup-current-pointer-cursor port (event-sheet event))
 		     pointer-cursor)
 	  (set-sheet-pointer-cursor port (event-sheet event) pointer-cursor))))

--- a/Backends/Standard/mm-sheets.lisp
+++ b/Backends/Standard/mm-sheets.lisp
@@ -43,19 +43,20 @@
 
 
 (defmethod note-sheet-transformation-changed :after ((sheet standard-multi-mirrored-sheet-mixin))
+  (repaint-background sheet sheet (sheet-region sheet))
+  (dispatch-repaint sheet (sheet-region sheet))
   (loop for child in (sheet-children sheet)
-     do (note-parent-mirror-geometry-changed child))
-  (repaint-mirrored-sheet-child (sheet-mirrored-ancestor sheet) sheet))
-
+     do (note-parent-mirror-geometry-changed child)))
+  
 (defmethod note-sheet-regions-changed :after ((sheet standard-multi-mirrored-sheet-mixin))
+  (repaint-background sheet sheet (sheet-region sheet))
+  (dispatch-repaint sheet (sheet-region sheet))
   (loop for child in (sheet-children sheet)
-     do (note-parent-mirror-geometry-changed child))
-  (repaint-mirrored-sheet-child (sheet-mirrored-ancestor sheet) sheet))
+     do (note-parent-mirror-geometry-changed child)))
 
 (defmethod %note-mirrored-sheet-child-region-changed
     ((sheet standard-multi-mirrored-sheet-mixin) child)
   (note-parent-mirror-geometry-changed child))
-
 
 (defmethod %note-mirrored-sheet-child-transformation-changed
     ((sheet standard-multi-mirrored-sheet-mixin) child)
@@ -66,7 +67,6 @@
 (defmethod note-parent-mirror-geometry-changed ((sheet standard-multi-mirrored-sheet-mixin))
   (note-sheet-transformation-changed sheet)
   (note-sheet-region-changed sheet))
-
 
 (defmethod note-parent-mirror-geometry-changed ((sheet basic-sheet))
   (loop for child in (sheet-children sheet)

--- a/Backends/Standard/mm-sheets.lisp
+++ b/Backends/Standard/mm-sheets.lisp
@@ -43,15 +43,23 @@
 
 
 (defmethod note-sheet-transformation-changed :after ((sheet standard-multi-mirrored-sheet-mixin))
-  (repaint-mirrored-sheet-child (sheet-mirrored-ancestor sheet) sheet)
   (loop for child in (sheet-children sheet)
-     do (note-parent-mirror-geometry-changed child)))
+     do (note-parent-mirror-geometry-changed child))
+  (repaint-mirrored-sheet-child (sheet-mirrored-ancestor sheet) sheet))
 
 (defmethod note-sheet-regions-changed :after ((sheet standard-multi-mirrored-sheet-mixin))
-  (repaint-mirrored-sheet-child (sheet-mirrored-ancestor sheet) sheet)
   (loop for child in (sheet-children sheet)
-     do (note-parent-mirror-geometry-changed child)))
-  
+     do (note-parent-mirror-geometry-changed child))
+  (repaint-mirrored-sheet-child (sheet-mirrored-ancestor sheet) sheet))
+
+(defmethod %note-mirrored-sheet-child-region-changed
+    ((sheet standard-multi-mirrored-sheet-mixin) child)
+  (note-parent-mirror-geometry-changed child))
+
+
+(defmethod %note-mirrored-sheet-child-transformation-changed
+    ((sheet standard-multi-mirrored-sheet-mixin) child)
+  (note-parent-mirror-geometry-changed child))
 
 (defgeneric note-parent-mirror-geometry-changed (sheet))
 
@@ -59,8 +67,8 @@
   (note-sheet-transformation-changed sheet)
   (note-sheet-region-changed sheet))
 
+
 (defmethod note-parent-mirror-geometry-changed ((sheet basic-sheet))
-  
   (loop for child in (sheet-children sheet)
      do (note-parent-mirror-geometry-changed child)))
 

--- a/Backends/Standard/package.lisp
+++ b/Backends/Standard/package.lisp
@@ -37,5 +37,7 @@
 		#:%note-sheet-repaint-request
 		#:%note-mirrored-sheet-child-repaint-request
 		#:dispatch-repaint
+		#:always-repaint-background-mixin
+		#:never-repaint-background-mixin
 		)
   )

--- a/Backends/Standard/package.lisp
+++ b/Backends/Standard/package.lisp
@@ -24,7 +24,6 @@
 
 		#:%%sheet-native-transformation
 		#:%%set-sheet-native-transformation
-		
 		#:%note-mirrored-sheet-child-grafted
 		#:%note-mirrored-sheet-child-degrafted
 		#:%note-mirrored-sheet-child-adopted

--- a/Backends/Standard/package.lisp
+++ b/Backends/Standard/package.lisp
@@ -34,5 +34,8 @@
 		#:%note-mirrored-sheet-child-transformation-changed
 		#:%note-sheet-pointer-cursor-changed
 		#:%note-mirrored-sheet-child-pointer-cursor-changed
+		#:%note-sheet-repaint-request
+		#:%note-mirrored-sheet-child-repaint-request
+		#:dispatch-repaint
 		)
   )

--- a/Backends/Standard/ports.lisp
+++ b/Backends/Standard/ports.lisp
@@ -8,3 +8,5 @@
 
 (defmethod set-sheet-pointer-cursor :before ((port standard-port) sheet cursor)
   (setf (gethash sheet (slot-value port 'mirrored-sheet->current-pointer-cursor)) cursor))
+
+

--- a/Backends/Standard/sheets.lisp
+++ b/Backends/Standard/sheets.lisp
@@ -25,6 +25,7 @@ that this might be different from the sheet's native region."
 
 (defmethod handle-event ((sheet standard-mirrored-sheet-mixin)
 			 (event window-configuration-event))
+
   (let ((x (window-configuration-event-x event))
 	(y (window-configuration-event-y event))
 	(width (window-configuration-event-width event))
@@ -40,7 +41,7 @@ that this might be different from the sheet's native region."
 (defmethod note-sheet-transformation-changed :before ((sheet standard-mirrored-sheet-mixin))
   (%update-mirror-geometry sheet))
 
-(defmethod note-sheet-regions-changed :before ((sheet standard-mirrored-sheet-mixin))
+(defmethod note-sheet-region-changed :before ((sheet standard-mirrored-sheet-mixin))
   (%update-mirror-geometry sheet))
 
 (defgeneric %update-mirror-geometry (sheet))
@@ -48,7 +49,7 @@ that this might be different from the sheet's native region."
 (defmethod %update-mirror-geometry ((sheet standard-mirrored-sheet-mixin))
   ())
 
- (defun %set-mirror-geometry (sheet x1 y1 x2 y2)
+(defun %set-mirror-geometry (sheet x1 y1 x2 y2)
   (let* ((MT (make-translation-transformation x1 y1))
 	 (MR (make-rectangle* 0 0 (round (- x2 x1)) (round (- y2 y1)))))
     (setf (%sheet-mirror-region sheet) MR)

--- a/Backends/Standard/sheets.lisp
+++ b/Backends/Standard/sheets.lisp
@@ -122,6 +122,19 @@ that this might be different from the sheet's native region."
 (defmethod %note-sheet-pointer-cursor-changed :after ((sheet standard-mirrored-sheet-mixin))
   (set-sheet-pointer-cursor (port sheet) sheet (sheet-pointer-cursor sheet)))
 
-(defmethod %note-mirrored-sheet-child-repaint-request :after
+(defmethod %note-mirrored-sheet-child-repaint-request 
     ((sheet standard-mirrored-sheet-mixin) child region)
   (repaint-background sheet child region))
+
+(defmethod %note-mirrored-sheet-child-repaint-request 
+    ((sheet standard-mirrored-sheet-mixin) (child always-repaint-background-mixin) region)
+  nil)
+
+(defmethod %note-mirrored-sheet-child-repaint-request 
+    ((sheet standard-mirrored-sheet-mixin) (child never-repaint-background-mixin) region)
+  nil)
+
+(defmethod %note-sheet-repaint-request ((sheet always-repaint-background-mixin)
+					region)
+  (repaint-background sheet sheet region))
+    

--- a/Core/clim-basic/graphics.lisp
+++ b/Core/clim-basic/graphics.lisp
@@ -779,13 +779,11 @@ position for the character."
 	       (pixmap-y2 (ceiling sheet-y2))
 	       (pixmap-width (- pixmap-x2 pixmap-x1))
 	       (pixmap-height (- pixmap-y2 pixmap-y1))
-	       (current-msheet-region (sheet-region msheet))
 	       (msheet-native (compose-transformation-with-translation
-			      msheet-transform
-			      (- pixmap-x1)
-			      (- pixmap-y1)))
-	       (pixmap (allocate-pixmap msheet pixmap-width pixmap-height))
-	       )
+			       msheet-transform
+			       (- pixmap-x1)
+			       (- pixmap-y1)))
+	       (pixmap (allocate-pixmap msheet pixmap-width pixmap-height)))
 	  (unless pixmap
 	    (error "Couldn't allocate pixmap")) 
 	  (multiple-value-bind (user-pixmap-x1 user-pixmap-y1)
@@ -796,47 +794,33 @@ position for the character."
 		  (untransform-position msheet-transform pixmap-x1 pixmap-y1)
 		(multiple-value-bind (msheet-pixmap-x2 msheet-pixmap-y2)
 		    (untransform-position msheet-transform pixmap-x2 pixmap-y2)
-		  (flet ((set-native (transform region sheet)
-			   (%%set-sheet-native-transformation transform sheet)
-			   (setf (slot-value sheet 'region) region)
-			   (invalidate-cached-regions sheet)
-			   (invalidate-cached-transformations sheet)
-			   (%%set-sheet-native-transformation transform sheet)
-			 ))
-		    ;; Assume that the scaling for the sheet-native
-		    ;; transformation for the pixmap will be the same as that of
-		    ;; the mirror .
-		    (unwind-protect
-			 (letf (((sheet-parent msheet) nil)
-				((sheet-direct-mirror msheet)
-				 (pixmap-mirror pixmap)))
-			   (unwind-protect
-				(let ((pixmap-region
-				       (region-intersection
-					(sheet-native-region sheet)
-					(make-bounding-rectangle msheet-pixmap-x1
-								 msheet-pixmap-y1
-								 msheet-pixmap-x2
-								 msheet-pixmap-y2))))
-				  (set-native msheet-native pixmap-region msheet)
-				  (with-drawing-options
-				      (medium :ink (medium-background medium))
-				    (medium-draw-rectangle* medium
-							    user-pixmap-x1
-							    user-pixmap-y1
-							    user-pixmap-x2
-							    user-pixmap-y2
-							    t))
-				  (funcall continuation sheet
-					   user-pixmap-x1 user-pixmap-y1
-					   user-pixmap-x2 user-pixmap-y2))
-			     (set-native msheet-transform
-					 current-msheet-region
-					 msheet)))
-		      (copy-from-pixmap pixmap 0 0
-					pixmap-width pixmap-height sheet
-					user-pixmap-x1 user-pixmap-y1)
-		      (deallocate-pixmap pixmap))))))))))))
+		  ;; Assume that the scaling for the sheet-native
+		  ;; transformation for the pixmap will be the same as that of
+		  ;; the mirror .
+		  (unwind-protect
+		       (let ((pixmap-region
+			      (region-intersection
+			       (sheet-native-region sheet)
+			       (make-bounding-rectangle msheet-pixmap-x1
+							msheet-pixmap-y1
+							msheet-pixmap-x2
+							msheet-pixmap-y2))))
+			 (with-temp-mirror%%% (msheet (pixmap-mirror pixmap) msheet-native pixmap-region)
+			   (with-drawing-options
+			       (medium :ink (medium-background medium))
+			     (medium-draw-rectangle* medium
+						     user-pixmap-x1
+						     user-pixmap-y1
+						     user-pixmap-x2
+						     user-pixmap-y2
+						     t))
+			   (funcall continuation sheet
+				    user-pixmap-x1 user-pixmap-y1
+				    user-pixmap-x2 user-pixmap-y2)))
+		    (copy-from-pixmap pixmap 0 0
+				      pixmap-width pixmap-height sheet
+				      user-pixmap-x1 user-pixmap-y1)
+		    (deallocate-pixmap pixmap)))))))))))
 
 (defmacro with-double-buffering (((sheet &rest bounds-args)
 				  (&rest pixmap-args))

--- a/Core/clim-basic/medium.lisp
+++ b/Core/clim-basic/medium.lisp
@@ -406,13 +406,13 @@
   (declare (ignore region))
   (let ((sheet (medium-sheet medium)))    
     (when sheet
-      (invalidate-cached-regions sheet))))
+      (%invalidate-cached-device-regions sheet))))
 
 (defmethod (setf medium-transformation) :after (transformation (medium medium))
   (declare (ignore transformation))
   (let ((sheet (medium-sheet medium)))
     (when sheet
-      (invalidate-cached-transformations sheet))))
+      (%invalidate-cached-device-transformations sheet))))
 
 (defmethod medium-merged-text-style ((medium medium))
   (merge-text-styles (medium-text-style medium) (medium-default-text-style medium)))

--- a/Core/clim-basic/repaint.lisp
+++ b/Core/clim-basic/repaint.lisp
@@ -132,3 +132,14 @@
   whether or not multiprocessing is supported."))
 
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; No Standard.
+
+;; as present in silica's implementation
+(defclass always-repaint-background-mixin () ())
+
+;; never repaint the background (only for speed)
+(defclass never-repaint-background-mixin () ())
+
+

--- a/Core/clim-basic/sheets.lisp
+++ b/Core/clim-basic/sheets.lisp
@@ -93,6 +93,13 @@
 (defgeneric %note-mirrored-sheet-child-pointer-cursor-changed (sheet child))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; non standard protocol
+
+(defgeneric %invalidate-cached-device-transformations (sheet))
+(defgeneric %invalidate-cached-device-regions (sheet))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;
 ;;;; sheet protocol class
 
@@ -122,7 +129,6 @@
 ;;; Native region is volatile, and is only computed at the first
 ;;; request when it's equal to nil.
 ;;;
-;;; Invalidate-cached-region method sets the native-region to nil.
 
 (defmethod sheet-parent ((sheet basic-sheet))
   nil)
@@ -428,6 +434,18 @@
           device-region nil))
   (loop for child in (sheet-children sheet)
         do (invalidate-cached-regions child)))
+
+(defmethod %invalidate-cached-device-transformations ((sheet basic-sheet))
+    (with-slots (device-transformation) sheet
+      (setf device-transformation nil))
+    (loop for child in (sheet-children sheet)
+       do (%invalidate-cached-device-transformations child)))
+
+(defmethod %invalidate-cached-device-regions ((sheet basic-sheet))
+    (with-slots (device-region) sheet
+      (setf device-region nil))
+    (loop for child in (sheet-children sheet)
+       do (%invalidate-cached-device-regions child)))
 
 (defmethod (setf sheet-transformation) :after
     (transformation (sheet basic-sheet))
@@ -766,3 +784,28 @@
  )
 
   
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; dangerous codes
+;;; postfix: %%% 
+;;;
+
+;; used by invoke-with-double-buffering
+(defmacro with-temp-mirror%%% ((mirrored-sheet new-mirror new-native-transformation new-region)
+			       &body body)
+  (let ((ori-native-transformation (gensym "ori-transformation"))
+	(ori-region (gensym "ori-region")))
+    ;; how use gensym in flet?
+    `(flet ((set-native (transform region sheet)
+	      (invalidate-cached-regions sheet)
+	      (invalidate-cached-transformations sheet)
+	      (%%set-sheet-native-transformation transform sheet)
+	      (setf (slot-value sheet 'region) region)))
+       (let ((,ori-native-transformation (sheet-native-transformation ,mirrored-sheet))
+	     (,ori-region (sheet-region ,mirrored-sheet)))
+	 (letf (((sheet-parent ,mirrored-sheet) nil)
+		((sheet-direct-mirror ,mirrored-sheet) ,new-mirror))
+	   (unwind-protect
+		(progn
+		  (set-native ,new-native-transformation ,new-region ,mirrored-sheet)
+		  ,@body)
+	     (set-native ,ori-native-transformation ,ori-region ,mirrored-sheet)))))))

--- a/Core/clim-basic/sheets.lisp
+++ b/Core/clim-basic/sheets.lisp
@@ -91,6 +91,8 @@
 (defgeneric %note-mirrored-sheet-child-transformation-changed (sheet child))
 (defgeneric %note-sheet-pointer-cursor-changed (sheet))
 (defgeneric %note-mirrored-sheet-child-pointer-cursor-changed (sheet child))
+(defgeneric %note-sheet-repaint-request (sheet region))
+(defgeneric %note-mirrored-sheet-child-repaint-request (sheet child region))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -781,9 +783,18 @@
 (defmethod %note-mirrored-sheet-child-transformation-changed ((sheet mirrored-sheet-mixin) child)
   )
 (defmethod %note-mirrored-sheet-child-pointer-cursor-changed ((sheet mirrored-sheet-mixin) child)
- )
+  )
+(defmethod %note-sheet-repaint-request ((sheet basic-sheet) region)
+  (let ((msheet (sheet-mirrored-ancestor sheet)))
+    (when (and msheet
+	       (not (eql msheet sheet)))
+      (%note-mirrored-sheet-child-repaint-request msheet sheet region))))
+(defmethod %note-mirrored-sheet-child-repaint-request ((sheet mirrored-sheet-mixin) child region)
+  )
 
-  
+
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; dangerous codes
 ;;; postfix: %%% 

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -938,7 +938,7 @@ order to produce a double-click")
 		    (clamp width  (sr-min-width pane)  (sr-max-width pane))
 		    (clamp height (sr-min-height pane) (sr-max-height pane)))))
 
-(defmethod note-sheet-region-changed :before ((pane top-level-sheet-pane))
+(defmethod note-sheet-region-changed :after ((pane top-level-sheet-pane))
   (with-bounding-rectangle* (x1 y1 x2 y2) (sheet-region pane)
     (allocate-space pane (- x2 x1) (- y2 y1))))
 

--- a/Examples/logic-cube.lisp
+++ b/Examples/logic-cube.lisp
@@ -32,7 +32,7 @@
 
 ;; Pane definition and puzzle generator
 
-(defclass logic-cube-pane (basic-gadget)
+(defclass logic-cube-pane (climi::never-repaint-background-mixin basic-gadget)
   ((background :initform (make-rgb-color 0.35 0.35 0.46) :reader background-color)
    (pitch :initform 0.0 :accessor pitch)
    (yaw   :initform 0.0 :accessor yaw)   


### PR DESCRIPTION
Hi Daniel,
A better pull request without a lot of merges...

I re-design a bit the repaint protocol. I take inspiration from clim2 of franz. 
The major issue was about the repainting of the background. X server takes care to repaint the background of only a mirrored sheet. Different backends can have different policies.
%note-mirrored-sheet-child-repaint-request and %note-sheet-repaint-request notifies to a backend that a sheet is going to be repainted.

A pane can use always-repaint-background-mixin or never-repaint-background-mixin to give an advice to the backend.

Any question?

Alessandro